### PR TITLE
Only deploy the standalone-full.xml during initial installation

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -67,6 +67,7 @@ bash 'Extract Wildfly' do
   chown #{wildfly['user']}:#{wildfly['group']} -R #{wildfly['base']}
   EOF
   action :nothing
+  notifies :create, "template[#{File.join(wildfly['base'], 'standalone', 'configuration', wildfly['sa']['conf'])}]" , :immediately
 end
 
 # Deploy Init Script
@@ -111,6 +112,7 @@ template File.join(wildfly['base'], 'standalone', 'configuration', wildfly['sa']
     s3_bucket: wildfly['aws']['s3_bucket']
   })
   notifies :restart, "service[#{wildfly['service']}]", :delayed
+  action :nothing
 end
 
 # => Configure Wildfly Standalone - MGMT Users


### PR DESCRIPTION
Hey,

The current cookbook will constantly overwrite the base config, causing deployments to be lost. Small change to make it create the config only during installation.

Cheers,

Hugo
