### PR TITLE
Fix when bind address is set to 0.0.0.0

### DIFF
--- a/templates/default/standalone-full-ha-aws.xml.erb
+++ b/templates/default/standalone-full-ha-aws.xml.erb
@@ -596,7 +596,12 @@
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
-            <wsdl-host>${jboss.bind.address:<%= @wsdl_int %>}</wsdl-host>
+           <% if "0.0.0.0" == @wsdl_int %>
+             <% Chef::Log.warn "Unable to set wsdl-host to a wildcard address, fallack to 127.0.0.1" %>
+             <wsdl-host>127.0.0.1</wsdl-host>
+           <% else %>
+             <wsdl-host>${jboss.bind.address:<%= @wsdl_int %>}</wsdl-host>
+           <% end %>
             <endpoint-config name="Standard-Endpoint-Config"/>
             <endpoint-config name="Recording-Endpoint-Config">
                 <pre-handler-chain name="recording-handlers" protocol-bindings="##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM">
@@ -609,10 +614,18 @@
     </profile>
     <interfaces>
         <interface name="management">
+          <% if "0.0.0.0" == @mgmt_int %>
+            <any-address/>
+          <% else %>
             <inet-address value="${jboss.bind.address.management:<%= @mgmt_int %>}"/>
+          <% end %>
         </interface>
         <interface name="public">
+          <% if "0.0.0.0" == @pub_int %>
+            <any-address/>
+          <% else %>
             <inet-address value="${jboss.bind.address:<%= @pub_int %>}"/>
+          <% end %>
         </interface>
         <!-- TODO - only show this if the jacorb subsystem is added  -->
         <interface name="unsecure">

--- a/templates/default/standalone-full-ha.xml.erb
+++ b/templates/default/standalone-full-ha.xml.erb
@@ -536,7 +536,12 @@
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
-            <wsdl-host>${jboss.bind.address:<%= @wsdl_int %>}</wsdl-host>
+           <% if "0.0.0.0" == @wsdl_int %>
+             <% Chef::Log.warn "Unable to set wsdl-host to a wildcard address, fallack to 127.0.0.1" %>
+             <wsdl-host>127.0.0.1</wsdl-host>
+           <% else %>
+             <wsdl-host>${jboss.bind.address:<%= @wsdl_int %>}</wsdl-host>
+           <% end %>
             <endpoint-config name="Standard-Endpoint-Config"/>
             <endpoint-config name="Recording-Endpoint-Config">
                 <pre-handler-chain name="recording-handlers" protocol-bindings="##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM">
@@ -549,10 +554,18 @@
     </profile>
     <interfaces>
         <interface name="management">
+          <% if "0.0.0.0" == @mgmt_int %>
+            <any-address/>
+          <% else %>
             <inet-address value="${jboss.bind.address.management:<%= @mgmt_int %>}"/>
+          <% end %>
         </interface>
         <interface name="public">
+          <% if "0.0.0.0" == @pub_int %>
+            <any-address/>
+          <% else %>
             <inet-address value="${jboss.bind.address:<%= @pub_int %>}"/>
+          <% end %>
         </interface>
         <!-- TODO - only show this if the jacorb subsystem is added  -->
         <interface name="unsecure">

--- a/templates/default/standalone-full.xml.erb
+++ b/templates/default/standalone-full.xml.erb
@@ -463,7 +463,12 @@
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
-            <wsdl-host>${jboss.bind.address:<%= @wsdl_int %>}</wsdl-host>
+           <% if "0.0.0.0" == @wsdl_int %>
+             <% Chef::Log.warn "Unable to set wsdl-host to a wildcard address, fallack to 127.0.0.1" %> 
+             <wsdl-host>127.0.0.1</wsdl-host>
+           <% else %>
+             <wsdl-host>${jboss.bind.address:<%= @wsdl_int %>}</wsdl-host>
+           <% end %>
             <endpoint-config name="Standard-Endpoint-Config"/>
             <endpoint-config name="Recording-Endpoint-Config">
                 <pre-handler-chain name="recording-handlers" protocol-bindings="##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM">
@@ -476,10 +481,18 @@
     </profile>
     <interfaces>
         <interface name="management">
+          <% if "0.0.0.0" == @mgmt_int %>
+            <any-address/>
+          <% else %>  
             <inet-address value="${jboss.bind.address.management:<%= @mgmt_int %>}"/>
+          <% end %>
         </interface>
         <interface name="public">
+          <% if "0.0.0.0" == @pub_int %>
+            <any-address/>
+          <% else %>  
             <inet-address value="${jboss.bind.address:<%= @pub_int %>}"/>
+          <% end %>
         </interface>
         <!-- TODO - only show this if the jacorb subsystem is added  -->
         <interface name="unsecure">

--- a/templates/default/standalone-ha.xml.erb
+++ b/templates/default/standalone-ha.xml.erb
@@ -421,7 +421,12 @@
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
-            <wsdl-host>${jboss.bind.address:<%= @wsdl_int %>}</wsdl-host>
+           <% if "0.0.0.0" == @wsdl_int %>
+             <% Chef::Log.warn "Unable to set wsdl-host to a wildcard address, fallack to 127.0.0.1" %>
+             <wsdl-host>127.0.0.1</wsdl-host>
+           <% else %>
+             <wsdl-host>${jboss.bind.address:<%= @wsdl_int %>}</wsdl-host>
+           <% end %>
             <endpoint-config name="Standard-Endpoint-Config"/>
             <endpoint-config name="Recording-Endpoint-Config">
                 <pre-handler-chain name="recording-handlers" protocol-bindings="##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM">
@@ -434,10 +439,18 @@
     </profile>
     <interfaces>
         <interface name="management">
+          <% if "0.0.0.0" == @mgmt_int %>
+            <any-address/>
+          <% else %>
             <inet-address value="${jboss.bind.address.management:<%= @mgmt_int %>}"/>
+          <% end %>
         </interface>
         <interface name="public">
+          <% if "0.0.0.0" == @pub_int %>
+            <any-address/>
+          <% else %>
             <inet-address value="${jboss.bind.address:<%= @pub_int %>}"/>
+          <% end %>
         </interface>
         <!-- TODO - only show this if the jacorb subsystem is added  -->
         <interface name="unsecure">

--- a/templates/default/standalone.xml.erb
+++ b/templates/default/standalone.xml.erb
@@ -375,7 +375,12 @@
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
-            <wsdl-host>${jboss.bind.address:<%= @wsdl_int %>}</wsdl-host>
+            <% if "0.0.0.0" == @wsdl_int %>
+              <% Chef::Log.warn "Unable to set wsdl-host to a wildcard address, fallack to 127.0.0.1" %>
+              <wsdl-host>127.0.0.1</wsdl-host>
+            <% else %>
+              <wsdl-host>${jboss.bind.address:<%= @wsdl_int %>}</wsdl-host>
+            <% end %>
             <endpoint-config name="Standard-Endpoint-Config"/>
             <endpoint-config name="Recording-Endpoint-Config">
                 <pre-handler-chain name="recording-handlers" protocol-bindings="##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM">
@@ -388,12 +393,19 @@
     </profile>
     <interfaces>
         <interface name="management">
+          <% if "0.0.0.0" == @mgmt_int %>
+            <any-address/>
+          <% else %>
             <inet-address value="${jboss.bind.address.management:<%= @mgmt_int %>}"/>
+          <% end %>
         </interface>
         <interface name="public">
+          <% if "0.0.0.0" == @pub_int %>
+            <any-address/>
+          <% else %>
             <inet-address value="${jboss.bind.address:<%= @pub_int %>}"/>
+          <% end %>
         </interface>
-        <!-- TODO - only show this if the jacorb subsystem is added  -->
         <interface name="unsecure">
             <!--
               ~  Used for IIOP sockets in the standard configuration.


### PR DESCRIPTION
Hey,

When some bind addresses are set to 0.0.0.0 (wildcard) it causes several problems in the wildfly server. For example the webservices wsdl-host does not accept 0.0.0.0 at all and crashes during startup.

Fixed by adding some conditional checks and setting the bind address to any for interfaces and logging a warning for the wsdl-host

Cheers,

Hugo
