### PR TITLE
use ::File::SEPARATOR and top level ::File classes within chef recipes

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -76,13 +76,13 @@ bash 'Extract Wildfly' do
   code <<-EOF
   tar xzf #{wildfly['version']}.tar.gz -C #{wildfly['base']} --strip 1
   chown #{wildfly['user']}:#{wildfly['group']} -R #{wildfly['base']}
-  rm -f #{File.join(wildfly['base'], '.chef_deployed')}
+  rm -f #{::File.join(wildfly['base'], '.chef_deployed')}
   EOF
   action :nothing
 end
 
 # Deploy Init Script
-template File.join('etc', 'init.d', wildfly['service']) do
+template ::File.join(::File::SEPARATOR, 'etc', 'init.d', wildfly['service']) do
   source 'wildfly-init-redhat.sh.erb'
   user 'root'
   group 'root'
@@ -90,7 +90,7 @@ template File.join('etc', 'init.d', wildfly['service']) do
 end
 
 # Deploy Service Configuration
-template File.join('etc', 'default', 'wildfly.conf') do
+template ::File.join(::File::SEPARATOR, 'etc', 'default', 'wildfly.conf') do
   source 'wildfly.conf.erb'
   user 'root'
   group 'root'
@@ -98,7 +98,7 @@ template File.join('etc', 'default', 'wildfly.conf') do
 end
 
 # => Configure Wildfly Standalone - Interfaces
-template File.join(wildfly['base'], 'standalone', 'configuration', wildfly['sa']['conf']) do
+template ::File.join(wildfly['base'], 'standalone', 'configuration', wildfly['sa']['conf']) do
   source "#{wildfly['sa']['conf']}.erb"
   user wildfly['user']
   group wildfly['group']
@@ -123,11 +123,11 @@ template File.join(wildfly['base'], 'standalone', 'configuration', wildfly['sa']
     s3_bucket: wildfly['aws']['s3_bucket']
   )
   notifies :restart, "service[#{wildfly['service']}]", :delayed
-  only_if { !File.exist?(File.join(wildfly['base'], '.chef_deployed')) || wildfly['enforce_config'] }
+  only_if { !::File.exist?(::File.join(wildfly['base'], '.chef_deployed')) || wildfly['enforce_config'] }
 end
 
 # => Configure Wildfly Standalone - MGMT Users
-template File.join(wildfly['base'], 'standalone', 'configuration', 'mgmt-users.properties') do
+template ::File.join(wildfly['base'], 'standalone', 'configuration', 'mgmt-users.properties') do
   source 'mgmt-users.properties.erb'
   user wildfly['user']
   group wildfly['group']
@@ -138,7 +138,7 @@ template File.join(wildfly['base'], 'standalone', 'configuration', 'mgmt-users.p
 end
 
 # => Configure Wildfly Standalone - Application Users
-template File.join(wildfly['base'], 'standalone', 'configuration', 'application-users.properties') do
+template ::File.join(wildfly['base'], 'standalone', 'configuration', 'application-users.properties') do
   source 'application-users.properties.erb'
   user wildfly['user']
   group wildfly['group']
@@ -149,7 +149,7 @@ template File.join(wildfly['base'], 'standalone', 'configuration', 'application-
 end
 
 # => Configure Wildfly Standalone - Application Roles
-template File.join(wildfly['base'], 'standalone', 'configuration', 'application-roles.properties') do
+template ::File.join(wildfly['base'], 'standalone', 'configuration', 'application-roles.properties') do
   source 'application-roles.properties.erb'
   user wildfly['user']
   group wildfly['group']
@@ -160,7 +160,7 @@ template File.join(wildfly['base'], 'standalone', 'configuration', 'application-
 end
 
 # => Configure Java Options
-template File.join(wildfly['base'], 'bin', 'standalone.conf') do
+template ::File.join(wildfly['base'], 'bin', 'standalone.conf') do
   source 'standalone.conf.erb'
   user wildfly['user']
   group wildfly['group']
@@ -172,22 +172,22 @@ template File.join(wildfly['base'], 'bin', 'standalone.conf') do
     preferipv4: wildfly['java_opts']['preferipv4'],
     headless: wildfly['java_opts']['headless']
   )
-  only_if { !File.exist?(File.join(wildfly['base'], '.chef_deployed')) || wildfly['enforce_config'] }
+  only_if { !::File.exist?(::File.join(wildfly['base'], '.chef_deployed')) || wildfly['enforce_config'] }
 end
 
 # => Configure Lograte for Wildfly
 template 'Wildfly Logrotate Configuration' do
-  path File.join('etc', 'logrotate.d', node['wildfly']['service'])
+  path ::File.join(::File::SEPARATOR, 'etc', 'logrotate.d', node['wildfly']['service'])
   source 'logrotate.erb'
   owner 'root'
   group 'root'
   mode '0644'
-  only_if { File.directory?('/etc/logrotate.d') && wildfly['log']['rotation'] }
+  only_if { ::File.directory?(::File.join(::File::SEPARATOR, 'etc', 'logrotate.d')) && wildfly['log']['rotation'] }
   action :create
 end
 
 # Create file to indicate deployment and prevent recurring configuration deployment
-file File.join(wildfly['base'], '.chef_deployed') do
+file ::File.join(wildfly['base'], '.chef_deployed') do
   owner wildfly['user']
   group wildfly['group']
   action :create_if_missing

--- a/recipes/mysql_connector.rb
+++ b/recipes/mysql_connector.rb
@@ -20,7 +20,7 @@
 #
 
 # => Make MySQL Connector/J Information Retrievable
-node.default['wildfly']['mysql']['version'] = File.basename(node['wildfly']['mysql']['url'], '.tar.gz')
+node.default['wildfly']['mysql']['version'] = ::File.basename(node['wildfly']['mysql']['url'], '.tar.gz')
 node.default['wildfly']['mysql']['jar'] = "#{node['wildfly']['mysql']['version']}-bin.jar"
 
 # => Shorten Hashes
@@ -28,7 +28,7 @@ wildfly = node['wildfly']
 mysql = node['wildfly']['mysql']
 
 # => Shorten Connector/J Directory Name
-connectorj_dir = File.join(wildfly['base'], 'modules', 'system', 'layers', 'base', 'com', 'mysql', 'main')
+connectorj_dir = ::File.join(wildfly['base'], 'modules', 'system', 'layers', 'base', 'com', 'mysql', 'main')
 
 # => Create MySQL Connector/J Directory
 directory connectorj_dir do
@@ -53,11 +53,11 @@ bash 'Extract ConnectorJ' do
   tar xzf #{mysql['version']}.tar.gz -C #{connectorj_dir} --strip 1 --no-anchored --wildcards #{mysql['jar']}
   chown #{wildfly['user']}:#{wildfly['group']} -R #{connectorj_dir}/../
   EOF
-  not_if { File.exist?(File.join(connectorj_dir, mysql['jar'])) }
+  not_if { ::File.exist?(::File.join(connectorj_dir, mysql['jar'])) }
 end
 
 # => Configure MySQL Connector/J Module
-template File.join(connectorj_dir, 'module.xml') do
+template ::File.join(connectorj_dir, 'module.xml') do
   source 'module.xml.erb'
   user wildfly['user']
   group wildfly['group']

--- a/recipes/mysql_datasources.rb
+++ b/recipes/mysql_datasources.rb
@@ -30,7 +30,7 @@ mysql = node['wildfly']['mysql']
 
 mysql['jndi']['datasources'].each do |source|
 # => Configure MySQL Datasource
-  template File.join(wildfly['base'], 'standalone', 'deployments', "#{File.basename(source['jndi_name'])}-ds.xml") do
+  template ::File.join(wildfly['base'], 'standalone', 'deployments', "#{::File.basename(source['jndi_name'])}-ds.xml") do
     source 'mysql-ds.xml.erb'
     user wildfly['user']
     group wildfly['group']

--- a/templates/default/logrotate.erb
+++ b/templates/default/logrotate.erb
@@ -3,7 +3,7 @@
 #
 
 <% wildfly = node['wildfly'] -%>
-<%= File.join(File.dirname(wildfly['log']['console_log']), '*.log') %> {
+<%= ::File.join(::File.dirname(wildfly['log']['console_log']), '*.log') %> {
         daily
         rotate <%= wildfly['log']['max_age'].to_i %>
         missingok

--- a/templates/default/wildfly.conf.erb
+++ b/templates/default/wildfly.conf.erb
@@ -9,7 +9,7 @@
 # Location of JDK	
 #
 <%- if node['wildfly']['java']['enforce_java_home'] === true %>
-<%- if node['java']['java_home'] && File.exists?(node['java']['java_home']) %>
+<%- if node['java']['java_home'] && ::File.exists?(node['java']['java_home']) %>
 JAVA_HOME="<%= node['java']['java_home'] %>"
 <%- else %>
 # JAVA_HOME="/usr/lib/jvm/default-java"
@@ -20,7 +20,7 @@ JAVA_HOME="<%= node['java']['java_home'] %>"
 
 # Location of WildFly
 #
-<%- if node['wildfly']['base'] && File.exists?(node['wildfly']['base']) %>
+<%- if node['wildfly']['base'] && ::File.exists?(node['wildfly']['base']) %>
 JBOSS_HOME="<%= node['wildfly']['base'] %>"
 <%- else %>
 # JBOSS_HOME="/opt/wildfly"


### PR DESCRIPTION
Hello!

I noticed while trying to do a chef-rewind on one of the template resources that the resource was called template[etc/init.d/wildfly] without the leading slash.  I know that chef solo and client are really changing directories internally to root when they run, but it might be better to use the full path name in these template resources as I got confused when my chef-rewind of template[/etc/init.d/wildfly] kept complaining that the resource wasn't found.  :)

Also, when using File.join's and other Ruby File class methods in chef code, I think the common practice is to use the ::File notation since Chef has a File class as well as ruby, and using ::File specifically uses ruby's.  I read about that practice here:

http://www.getchef.com/blog/2013/09/04/demystifying-common-idioms-in-chef-recipes/

Great cookbook and thank you for opening it up to the community!
