### PR TITLE
Fixes: Berksfile use Supermarket & Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,23 @@
+language: ruby
+cache: bundler
+sudo: false
+
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.0
+  - 2.1
+  - 2.2
+
+bundler_args: --without development kitchen_docker kitchen_vagrant
+
 script:
   - bundle exec foodcritic -f any . --tags ~FC007 --tags ~FC024 --tags ~FC048
   # - bundle exec rspec --color --format progress
   - bundle exec rubocop
+
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/dc143a4bf4fb95b75249
+    on_success: change  # options: [always|never|change] default: always
+    on_failure: always  # options: [always|never|change] default: always
+    on_start: never     # options: [always|never|change] default: always

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-source 'http://api.berkshelf.com'
+source 'https://supermarket.chef.io'
 
 metadata

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Wildfly Cookbook
 Cookbook to deploy Wildfly Java Application Server
 
+[![Cookbook](http://img.shields.io/cookbook/v/wildfly.svg)](https://github.com/bdwyertech/chef-wildfly)
+[![Build Status](https://travis-ci.org/bdwyertech/chef-wildfly.svg)](https://travis-ci.org/bdwyertech/chef-wildfly)
+[![Gitter chat](https://img.shields.io/badge/Gitter-bdwyertech%2Fwildfly-brightgreen.svg)](https://gitter.im/bdwyertech/chef-wildfly)
+
 # Requirements
 - Chef Client 11+
 - Java Cookbook (ignored if node['wildfly']['install_java'] is false)


### PR DESCRIPTION
- Update Berksfile source URL
- Fix Travis' Ruby versions for berkshelf-api-client ruby version constraint
- Move Travis to the containerized build system (`sudo: false`)