### PR TITLE
Adding cookbook to template so I can add a wrapper cookbook to overwrite

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -92,3 +92,6 @@ default['wildfly']['initd']['shutdown_wait'] = '60'
 default['wildfly']['java']['enforce_java_home'] = true
 
 default['wildfly']['install_java'] = true
+
+# adding template attribute for wrapper cookbook
+default['wildfly']['cookbook'] = 'wildfly'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -100,6 +100,7 @@ template ::File.join(::File::SEPARATOR, 'etc', 'init.d', wildfly['service']) do
   user 'root'
   group 'root'
   mode '0755'
+  cookbooks node['wildfly']['cookbook']
 end
 
 # Deploy Service Configuration


### PR DESCRIPTION
Adding cookbook to template so I can add a wrapper cookbook to overwrite. I need the ablity to add in a environment variable in the init.d script. I would like this to be in the main cookbook so I do not have to maintain this with the wrapper cookbook.  