### PR TITLE
necessary changes to run multiple instances

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -61,6 +61,7 @@ default['wildfly']['int']['pub']['https_port'] = '8443'
 
 default['wildfly']['int']['wsdl']['bind'] = '0.0.0.0'
 default['wildfly']['int']['ajp']['port'] = '8009'
+default['wildfly']['int']['jacorb']['port'] = '3528'
 
 # => Use this to offset all port bindings.  Each binding will be incremented by this value.
 default['wildfly']['int']['port_binding_offset'] = '0'
@@ -77,7 +78,7 @@ default['wildfly']['smtp']['username'] = nil
 default['wildfly']['smtp']['password'] = nil
 
 # => Console Log Location
-default['wildfly']['log']['console_log'] = '/var/log/wildfly/console.log'
+default['wildfly']['log']['console_log'] = "/var/log/#{node['wildfly']['service']}/console.log"
 # => Enable Log Rotation on *.log in Console Log Directory
 default['wildfly']['log']['rotation'] = true
 # => Purge rotated logs older than this many days
@@ -86,6 +87,9 @@ default['wildfly']['log']['max_age'] = 375
 # => Init Script Timeouts (Seconds)
 default['wildfly']['initd']['startup_wait'] = '60'
 default['wildfly']['initd']['shutdown_wait'] = '60'
+
+# => Init Script Pid file
+default['wildfly']['initd']['pid_file'] = "/var/run/#{node['wildfly']['service']}/wildfly.pid"
 
 # => Hardcode JAVA_HOME into init.d configuration.
 # => Based on value of node['java']['java_home']

--- a/providers/attribute.rb
+++ b/providers/attribute.rb
@@ -57,11 +57,11 @@ end
 private
 
 def attribute_exists?
-  result = shell_out("bin/jboss-cli.sh -c '#{current_resource.path}:read-attribute(name=#{current_resource.parameter})'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
+  result = shell_out("bin/jboss-cli.sh -c controller=localhost:#{node['wildfly']['int']['mgmt']['http_port']} '#{current_resource.path}:read-attribute(name=#{current_resource.parameter})'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
   result.stdout.include? " #{current_resource.value}"
 end
 
 def attribute_set
-  result = shell_out("bin/jboss-cli.sh -c '#{current_resource.path}:write-attribute(name=#{current_resource.parameter},value=#{current_resource.value})'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
+  result = shell_out("bin/jboss-cli.sh -c controller=localhost:#{node['wildfly']['int']['mgmt']['http_port']} '#{current_resource.path}:write-attribute(name=#{current_resource.parameter},value=#{current_resource.value})'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
   result.exitstatus == 0
 end

--- a/providers/datasource.rb
+++ b/providers/datasource.rb
@@ -57,7 +57,7 @@ end
 private
 
 def datasource_exists?(name)
-  result = shell_out("su #{node['wildfly']['user']} -s /bin/bash -c \"#{node['wildfly']['base']}/bin/jboss-cli.sh -c ' /subsystem=datasources/data-source=#{name}:read-resource'\"")
+  result = shell_out("su #{node['wildfly']['user']} -s /bin/bash -c \"#{node['wildfly']['base']}/bin/jboss-cli.sh -c controller=localhost:#{node['wildfly']['int']['mgmt']['http_port']} ' /subsystem=datasources/data-source=#{name}:read-resource'\"")
   result.exitstatus == 0
 end
 
@@ -66,7 +66,7 @@ def create_datasource
     user node['wildfly']['user']
     cwd node['wildfly']['base']
     code <<-EOH
-      bin/jboss-cli.sh -c command="data-source add --name=#{new_resource.name} --jndi-name=#{new_resource.jndiname} --driver-name=#{new_resource.drivername} --connection-url=#{new_resource.connectionurl}"
+      bin/jboss-cli.sh -c controller=localhost:#{node['wildfly']['int']['mgmt']['http_port']} command="data-source add --name=#{new_resource.name} --jndi-name=#{new_resource.jndiname} --driver-name=#{new_resource.drivername} --connection-url=#{new_resource.connectionurl}"
     EOH
   end
 end
@@ -76,7 +76,7 @@ def delete_datasource
     user node['wildfly']['user']
     cwd node['wildfly']['base']
     code <<-EOH
-      bin/jboss-cli.sh -c command="data-source remove --name=#{new_resource.name}"
+      bin/jboss-cli.sh -c controller=localhost:#{node['wildfly']['int']['mgmt']['http_port']} command="data-source remove --name=#{new_resource.name}"
     EOH
   end
 end

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -111,7 +111,7 @@ end
 def deploy_install(source, name, runtime_name)
   Chef::Log.info "Deploying #{name}"
   converge_by((source == '' ? 'Enabling' : 'Deploying') + " #{detailed_name(runtime_name, name)}") do
-    result = shell_out("bin/jboss-cli.sh -c ' deploy #{source} --name=#{name} --runtime-name=#{runtime_name}'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
+    result = shell_out("bin/jboss-cli.sh -c controller=localhost:#{node['wildfly']['int']['mgmt']['http_port']} ' deploy #{source} --name=#{name} --runtime-name=#{runtime_name}'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
     result.error! if result.exitstatus != 0
   end
   true
@@ -122,7 +122,7 @@ def deploy_remove(runtime_name, keep_content = false)
   deployments[runtime_name].each do |deployed|
     converge_by((keep_content ? 'Disabling' : 'Removing') + " #{detailed_name(runtime_name, deployed.keys.first)}") do
       Chef::Log.info 'Undeploying #{detailed_name(runtime_name, deployed.keys.first)}'
-      result = shell_out("bin/jboss-cli.sh -c ' undeploy #{deployed.keys.first} #{keep_content ? '--keep-content' : ''}'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
+      result = shell_out("bin/jboss-cli.sh -c controller=localhost:#{node['wildfly']['int']['mgmt']['http_port']} ' undeploy #{deployed.keys.first} #{keep_content ? '--keep-content' : ''}'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
       result.error! if result.exitstatus != 0
     end
   end
@@ -132,7 +132,7 @@ end
 def read_deployment_details(refresh = false)
   if !@deployment_details || refresh
     Chef::Log.info 'Getting list of deployed applications'
-    data = shell_out("bin/jboss-cli.sh -c ' deployment-info '", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
+    data = shell_out("bin/jboss-cli.sh -c controller=localhost:#{node['wildfly']['int']['mgmt']['http_port']} ' deployment-info '", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
     @deployment_details = format_output(data.stdout)
   end
   @deployment_details

--- a/providers/logcategory.rb
+++ b/providers/logcategory.rb
@@ -57,7 +57,7 @@ end
 private
 
 def logcategory_exists?(name)
-  result = shell_out("su #{node['wildfly']['user']} -s /bin/bash -c \"#{node['wildfly']['base']}/bin/jboss-cli.sh -c ' /subsystem=logging/logger=#{name}:read-resource'\"")
+  result = shell_out("su #{node['wildfly']['user']} -s /bin/bash -c \"#{node['wildfly']['base']}/bin/jboss-cli.sh -c controller=localhost:#{node['wildfly']['int']['mgmt']['http_port']} ' /subsystem=logging/logger=#{name}:read-resource'\"")
   result.exitstatus == 0
 end
 
@@ -75,7 +75,7 @@ def create_logcategory
     user node['wildfly']['user']
     cwd node['wildfly']['base']
     code <<-EOH
-      bin/jboss-cli.sh -c command="/subsystem=logging/logger=#{new_resource.name}:add(use-parent-handlers=#{new_resource.use_parent_handlers},level=#{new_resource.level},handlers=#{handlers})"
+      bin/jboss-cli.sh -c controller=localhost:#{node['wildfly']['int']['mgmt']['http_port']} command="/subsystem=logging/logger=#{new_resource.name}:add(use-parent-handlers=#{new_resource.use_parent_handlers},level=#{new_resource.level},handlers=#{handlers})"
     EOH
   end
 end
@@ -85,7 +85,7 @@ def delete_logcategory
     user node['wildfly']['user']
     cwd node['wildfly']['base']
     code <<-EOH
-      `su #{node['wildfly']['user']} -s /bin/bash -c "#{node['wildfly']['base']}/bin/jboss-cli.sh -c ' /subsystem=logging/logger=#{name}:remove'"`
+      `su #{node['wildfly']['user']} -s /bin/bash -c "#{node['wildfly']['base']}/bin/jboss-cli.sh -c controller=localhost:#{node['wildfly']['int']['mgmt']['http_port']} ' /subsystem=logging/logger=#{name}:remove'"`
     EOH
   end
 end

--- a/providers/loghandler.rb
+++ b/providers/loghandler.rb
@@ -51,7 +51,7 @@ end
 private
 
 def loghandler_exists?(name)
-  result = shell_out("su #{node['wildfly']['user']} -s /bin/bash -c \"#{node['wildfly']['base']}/bin/jboss-cli.sh -c ' /subsystem=logging/#{new_resource.type}=#{name}:read-resource'\"")
+  result = shell_out("su #{node['wildfly']['user']} -s /bin/bash -c \"#{node['wildfly']['base']}/bin/jboss-cli.sh -c controller=localhost:#{node['wildfly']['int']['mgmt']['http_port']} ' /subsystem=logging/#{new_resource.type}=#{name}:read-resource'\"")
   result.exitstatus == 0
 end
 
@@ -60,7 +60,7 @@ def create_loghandler
     user node['wildfly']['user']
     cwd node['wildfly']['base']
     code <<-EOH
-      bin/jboss-cli.sh -c command="/subsystem=logging/#{new_resource.type}=#{new_resource.name}:add(hostname=#{new_resource.hostname},app-name=#{new_resource.app_name})"
+      bin/jboss-cli.sh -c controller=localhost:#{node['wildfly']['int']['mgmt']['http_port']} command="/subsystem=logging/#{new_resource.type}=#{new_resource.name}:add(hostname=#{new_resource.hostname},app-name=#{new_resource.app_name})"
     EOH
   end
 end
@@ -70,7 +70,7 @@ def delete_loghandler
     user node['wildfly']['user']
     cwd node['wildfly']['base']
     code <<-EOH
-      `su #{node['wildfly']['user']} -s /bin/bash -c "#{node['wildfly']['base']}/bin/jboss-cli.sh -c ' /subsystem=logging/#{new_resource.type}=#{name}:remove'"`
+      `su #{node['wildfly']['user']} -s /bin/bash -c "#{node['wildfly']['base']}/bin/jboss-cli.sh -c controller=localhost:#{node['wildfly']['int']['mgmt']['http_port']} ' /subsystem=logging/#{new_resource.type}=#{name}:remove'"`
     EOH
   end
 end

--- a/providers/property.rb
+++ b/providers/property.rb
@@ -67,25 +67,25 @@ def notify?
 end
 
 def property_value_exists?
-  result = shell_out("bin/jboss-cli.sh -c '/system-property=#{current_resource.property}:read-attribute(name=value)'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
+  result = shell_out("bin/jboss-cli.sh -c controller=localhost:#{node['wildfly']['int']['mgmt']['http_port']} '/system-property=#{current_resource.property}:read-attribute(name=value)'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
   result.stdout.include? " \"#{current_resource.value}\""
 end
 
 def property_exists?
-  result = shell_out("bin/jboss-cli.sh -c '/system-property=#{current_resource.property}:read-resource'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
+  result = shell_out("bin/jboss-cli.sh -c controller=localhost:#{node['wildfly']['int']['mgmt']['http_port']} '/system-property=#{current_resource.property}:read-resource'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
   result.exitstatus == 0
 end
 
 def property_set
   if property_exists?
-    result = shell_out("bin/jboss-cli.sh -c '/system-property=#{current_resource.property}:write-attribute(name=value,value=#{Shellwords.escape(current_resource.value)})'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
+    result = shell_out("bin/jboss-cli.sh -c controller=localhost:#{node['wildfly']['int']['mgmt']['http_port']} '/system-property=#{current_resource.property}:write-attribute(name=value,value=#{Shellwords.escape(current_resource.value)})'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
   else
-    result = shell_out("bin/jboss-cli.sh -c '/system-property=#{current_resource.property}:add(value=#{Shellwords.escape(current_resource.value)})'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
+    result = shell_out("bin/jboss-cli.sh -c controller=localhost:#{node['wildfly']['int']['mgmt']['http_port']} '/system-property=#{current_resource.property}:add(value=#{Shellwords.escape(current_resource.value)})'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
   end
   result.exitstatus == 0
 end
 
 def property_delete
-  result = shell_out("bin/jboss-cli.sh -c '/system-property=#{current_resource.property}:remove()'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
+  result = shell_out("bin/jboss-cli.sh -c controller=localhost:#{node['wildfly']['int']['mgmt']['http_port']} '/system-property=#{current_resource.property}:remove()'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
   result.exitstatus == 0
 end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -103,7 +103,7 @@ template ::File.join(::File::SEPARATOR, 'etc', 'init.d', wildfly['service']) do
 end
 
 # Deploy Service Configuration
-template ::File.join(::File::SEPARATOR, 'etc', 'default', 'wildfly.conf') do
+template ::File.join(::File::SEPARATOR, 'etc', 'default', "#{node['wildfly']['service']}.conf") do
   source 'wildfly.conf.erb'
   user 'root'
   group 'root'
@@ -126,6 +126,7 @@ template ::File.join(wildfly['base'], 'standalone', 'configuration', wildfly['sa
     pub_https_port: wildfly['int']['pub']['https_port'],
     wsdl_int: wildfly['int']['wsdl']['bind'],
     ajp_port: wildfly['int']['ajp']['port'],
+    jacorb_port: wildfly['int']['jacorb']['port'],
     smtp_host: wildfly['smtp']['host'],
     smtp_port: wildfly['smtp']['port'],
     smtp_ssl: wildfly['smtp']['ssl'],

--- a/templates/default/standalone-full-ha-aws.xml.erb
+++ b/templates/default/standalone-full-ha-aws.xml.erb
@@ -643,7 +643,7 @@
         <socket-binding name="ajp" port="${jboss.ajp.port:<%= @ajp_port %>}"/>
         <socket-binding name="http" port="${jboss.http.port:<%= @pub_http_port %>}"/>
         <socket-binding name="https" port="${jboss.https.port:<%= @pub_https_port %>}"/>
-        <socket-binding name="jacorb" interface="unsecure" port="3528"/>
+        <socket-binding name="jacorb" interface="unsecure" port="<%= @jacorb_port %>"/>
         <socket-binding name="jacorb-ssl" interface="unsecure" port="3529"/>
         <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
         <socket-binding name="jgroups-tcp" port="7600"/>

--- a/templates/default/standalone-full-ha.xml.erb
+++ b/templates/default/standalone-full-ha.xml.erb
@@ -582,7 +582,7 @@
         <socket-binding name="ajp" port="${jboss.ajp.port:<%= @ajp_port %>}"/>
         <socket-binding name="http" port="${jboss.http.port:<%= @pub_http_port %>}"/>
         <socket-binding name="https" port="${jboss.https.port:<%= @pub_https_port %>}"/>
-        <socket-binding name="jacorb" interface="unsecure" port="3528"/>
+        <socket-binding name="jacorb" interface="unsecure" port="<%= @jacorb_port %>"/>
         <socket-binding name="jacorb-ssl" interface="unsecure" port="3529"/>
         <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
         <socket-binding name="jgroups-tcp" port="7600"/>

--- a/templates/default/standalone-full.xml.erb
+++ b/templates/default/standalone-full.xml.erb
@@ -513,7 +513,7 @@
         <socket-binding name="ajp" port="${jboss.ajp.port:<%= @ajp_port %>}"/>
         <socket-binding name="http" port="${jboss.http.port:<%= @pub_http_port %>}"/>
         <socket-binding name="https" port="${jboss.https.port:<%= @pub_https_port %>}"/>
-        <socket-binding name="jacorb" interface="unsecure" port="3528"/>
+        <socket-binding name="jacorb" interface="unsecure" port="<%= @jacorb_port %>"/>
         <socket-binding name="jacorb-ssl" interface="unsecure" port="3529"/>
         <socket-binding name="messaging-group" port="0" multicast-address="${jboss.messaging.group.address:231.7.7.7}" multicast-port="${jboss.messaging.group.port:9876}"/>
         <socket-binding name="txn-recovery-environment" port="4712"/>

--- a/templates/default/wildfly-init-debian.sh.erb
+++ b/templates/default/wildfly-init-debian.sh.erb
@@ -21,7 +21,7 @@
 
 NAME=wildfly
 DESC="WildFly Application Server"
-DEFAULT="/etc/default/wildfly.conf"
+DEFAULT="/etc/default/<%= node['wildfly']['service'] %>.conf"
 
 # Check privileges
 if [ `id -u` -ne 0 ]; then

--- a/templates/default/wildfly-init-redhat.sh.erb
+++ b/templates/default/wildfly-init-redhat.sh.erb
@@ -20,7 +20,7 @@ export JAVA_HOME
 
 # Load JBoss AS init.d configuration.
 if [ -z "$JBOSS_CONF" ]; then
-	JBOSS_CONF="/etc/default/wildfly.conf"
+  JBOSS_CONF="/etc/default/<%= node['wildfly']['service'] %>.conf"
 fi
 
 [ -r "$JBOSS_CONF" ] && . "${JBOSS_CONF}"

--- a/templates/default/wildfly.conf.erb
+++ b/templates/default/wildfly.conf.erb
@@ -86,3 +86,9 @@ JBOSS_CONSOLE_LOG="<%= node['wildfly']['log']['console_log'] %>"
 <%- else %>
 # JBOSS_CONSOLE_LOG="/var/log/wildfly/console.log"
 <%- end %>
+
+<%- if node['wildfly']['initd']['pid_file'] %>
+JBOSS_PIDFILE="<%= node['wildfly']['initd']['pid_file'] %>"
+<%- else %>
+# JBOSS_PIDFILE="/var/run/wildfly/wildfly.pid"
+# <%- end %>


### PR DESCRIPTION
In a non ideal situation where I need to run multiple wildfly instance on the same host which isn't possible with the current state of the cookbook.

These are some necessary changes to fully split the instance configurations.

It would ultimately be great if the install was an lwrp. A good example is the httpd cookbook
