### PR TITLE
Reload systemd configuration after adding/changing wildfly service

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -101,11 +101,11 @@ template ::File.join(::File::SEPARATOR, 'etc', 'init.d', wildfly['service']) do
   group 'root'
   mode '0755'
 
-  notifies :run, 'execute[systemctl daemon-reload]', :immediately  if node['init_package'] == 'systemd'
+  notifies :run, 'execute[systemctl daemon-reload]', :immediately if node['init_package'] == 'systemd'
 end
 
 execute 'systemctl daemon-reload' do
-	action :nothing
+  action :nothing
 end
 
 # Deploy Service Configuration

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -100,6 +100,12 @@ template ::File.join(::File::SEPARATOR, 'etc', 'init.d', wildfly['service']) do
   user 'root'
   group 'root'
   mode '0755'
+
+  notifies :run, 'execute[systemctl daemon-reload]', :immediately  if node['init_package'] == 'systemd'
+end
+
+execute 'systemctl daemon-reload' do
+	action :nothing
 end
 
 # Deploy Service Configuration


### PR DESCRIPTION
To prevent WildFly to fail its first start on systemd based systems
reload the configuration after adding or changing the init script.
