### PR TITLE
Leading zeroes in property values were being dropped

### DIFF
--- a/providers/property.rb
+++ b/providers/property.rb
@@ -20,8 +20,6 @@ require 'etc'
 require 'shellwords'
 include Chef::Mixin::ShellOut
 
-use_inline_resources
-
 # Support whyrun
 def whyrun_supported?
   true
@@ -80,9 +78,9 @@ end
 
 def property_set
   if property_exists?
-    result = shell_out("bin/jboss-cli.sh -c '/system-property=#{current_resource.property}:write-attribute(name=value,value=#{Shellwords.escape(current_resource.value)})'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
+    result = shell_out("bin/jboss-cli.sh -c '/system-property=#{current_resource.property}:write-attribute(name=value,value=\"#{Shellwords.escape(current_resource.value)}\")'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
   else
-    result = shell_out("bin/jboss-cli.sh -c '/system-property=#{current_resource.property}:add(value=#{Shellwords.escape(current_resource.value)})'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
+    result = shell_out("bin/jboss-cli.sh -c '/system-property=#{current_resource.property}:add(value=\"#{Shellwords.escape(current_resource.value)}\")'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
   end
   result.exitstatus == 0
 end

--- a/providers/property.rb
+++ b/providers/property.rb
@@ -20,6 +20,8 @@ require 'etc'
 require 'shellwords'
 include Chef::Mixin::ShellOut
 
+use_inline_resources
+
 # Support whyrun
 def whyrun_supported?
   true


### PR DESCRIPTION
Leading zeroes in property values were being dropped. Example:

A value of "001" was written to the standalone-full.xml as "1".

It seems that the jboss-cli was converting the values to integers before writing it to the config file.

Simply adding double-quotes around the value in the provider solved the issue.
