### PR TITLE
Optionally allow disabling escape of property value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
         #  - 2.1
         #  - 2.2
   - 2.2.3
+  - 2.3
 
 bundler_args: --without development kitchen_docker kitchen_vagrant
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://supermarket.chef.io'
 
 metadata

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
+
 source 'https://rubygems.org'
 
 gem 'berkshelf'

--- a/Thorfile
+++ b/Thorfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # encoding: utf-8
 
 require 'bundler'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@
 ENV['VAGRANT_DEFAULT_PROVIDER'] = 'vmware_workstation'
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
-VAGRANTFILE_API_VERSION = '2'.freeze
+VAGRANTFILE_API_VERSION = '2'
 
 Vagrant.require_version '>= 1.5.0'
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@
 ENV['VAGRANT_DEFAULT_PROVIDER'] = 'vmware_workstation'
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
-VAGRANTFILE_API_VERSION = '2'
+VAGRANTFILE_API_VERSION = '2'.freeze
 
 Vagrant.require_version '>= 1.5.0'
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,9 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
+
 # -*- mode: ruby -*-
+
 # vi: set ft=ruby :
 
 # Set the default provider to VMware Workstation

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
-#
+
 # Copyright (C) 2014 Brian Dwyer - Intelligent Digital Services
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/attributes/java.rb
+++ b/attributes/java.rb
@@ -1,6 +1,9 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 # rubocop:disable LineLength
 #
+
+# encoding: UTF-8
+
 # Copyright (C) 2014 Brian Dwyer - Intelligent Digital Services
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/attributes/java_opts.rb
+++ b/attributes/java_opts.rb
@@ -1,6 +1,8 @@
-# Encoding: UTF-8
+# frozen_string_literal: true
 # rubocop:disable LineLength
-#
+
+# encoding: UTF-8
+
 # Copyright (C) 2014 Brian Dwyer - Intelligent Digital Services
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,6 +30,6 @@ default['wildfly']['java_opts']['preferipv4'] = 'true'
 default['wildfly']['java_opts']['headless'] = 'true'
 
 # => Specify other java options in this space-deliniated array.
-default['wildfly']['java_opts']['other'] = %w(
+default['wildfly']['java_opts']['other'] = %w[
 
-)
+]

--- a/attributes/mysql.rb
+++ b/attributes/mysql.rb
@@ -1,6 +1,8 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 # rubocop:disable LineLength
-#
+
+# encoding: UTF-8
+
 # Copyright (C) 2014 Brian Dwyer - Intelligent Digital Services
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/attributes/mysql_datasources.rb
+++ b/attributes/mysql_datasources.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
-#
+
 # Copyright (C) 2014 Brian Dwyer - Intelligent Digital Services
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/attributes/postgres.rb
+++ b/attributes/postgres.rb
@@ -1,6 +1,8 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 # rubocop:disable LineLength
-#
+
+# encoding: UTF-8
+
 # Copyright (C) 2014 Brian Dwyer - Intelligent Digital Services
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/attributes/postgres_datasources.rb
+++ b/attributes/postgres_datasources.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 default['wildfly']['postgresql']['jndi']['datasources'] = [
   {
     pool_name: 'test',

--- a/attributes/system_properties.rb
+++ b/attributes/system_properties.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
-#
+
 # Copyright (C) 2014 Brian Dwyer - Intelligent Digital Services
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/attributes/users.rb
+++ b/attributes/users.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
-#
+
 # Copyright (C) 2014 Brian Dwyer - Intelligent Digital Services
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 # rubocop:disable Style/AccessorMethodName
+
 if defined?(ChefSpec)
   def set_wildfly_attribute(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:wildfly_attribute, :create, resource_name)

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
 
 name             'wildfly'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 name             'wildfly'
 maintainer       'Brian Dwyer - Intelligent Digital Services'
 maintainer_email 'bdwyertech'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,6 +6,7 @@ license          'Apache-2.0'
 description      'Installs/Configures wildfly'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.4.2'
+chef_version     '<= 12.4'
 
 supports 'centos'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@
 name             'wildfly'
 maintainer       'Brian Dwyer - Intelligent Digital Services'
 maintainer_email 'bdwyertech'
-license          'Apache License, Version 2.0'
+license          'Apache-2.0'
 description      'Installs/Configures wildfly'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.4.2'

--- a/providers/attribute.rb
+++ b/providers/attribute.rb
@@ -1,6 +1,8 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 # rubocop:disable LineLength, Metrics/AbcSize, MethodLength
-#
+
+# encoding: UTF-8
+
 # Copyright (C) 2014 Brian Dwyer - Intelligent Digital Services
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/providers/datasource.rb
+++ b/providers/datasource.rb
@@ -1,6 +1,8 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 # rubocop:disable LineLength, Metrics/AbcSize
-#
+
+# encoding: UTF-8
+
 # Copyright (C) 2014 Brian Dwyer - Intelligent Digital Services
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -67,7 +69,7 @@ end
 private
 
 def create_datasource
-  params = %W(--name=#{new_resource.name} --jndi-name=#{new_resource.jndiname} --driver-name=#{new_resource.drivername} --connection-url=#{new_resource.connectionurl})
+  params = %W[--name=#{new_resource.name} --jndi-name=#{new_resource.jndiname} --driver-name=#{new_resource.drivername} --connection-url=#{new_resource.connectionurl}]
   params << "--user-name=#{new_resource.username}" if new_resource.username
   params << "--password=#{new_resource.password}" if new_resource.password
 

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -1,6 +1,8 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 # rubocop:disable LineLength, Metrics/AbcSize
-#
+
+# encoding: UTF-8
+
 # Copyright (C) 2014 Brian Dwyer - Intelligent Digital Services
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/providers/logcategory.rb
+++ b/providers/logcategory.rb
@@ -1,6 +1,8 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 # rubocop:disable LineLength, MethodLength, Metrics/AbcSize
-#
+
+# encoding: UTF-8
+
 # Copyright (C) 2014 Brian Dwyer - Intelligent Digital Services
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/providers/loghandler.rb
+++ b/providers/loghandler.rb
@@ -1,6 +1,8 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 # rubocop:disable LineLength, Metrics/AbcSize
-#
+
+# encoding: UTF-8
+
 # Copyright (C) 2014 Brian Dwyer - Intelligent Digital Services
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/providers/property.rb
+++ b/providers/property.rb
@@ -1,6 +1,8 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 # rubocop:disable LineLength, Metrics/AbcSize
-#
+
+# encoding: UTF-8
+
 # Copyright (C) 2014 Brian Dwyer - Intelligent Digital Services
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/providers/property.rb
+++ b/providers/property.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# rubocop:disable LineLength, Metrics/AbcSize
+# rubocop:disable LineLength, Metrics/AbcSize, Style/MethodLength
 
 # encoding: UTF-8
 

--- a/providers/property.rb
+++ b/providers/property.rb
@@ -54,6 +54,7 @@ def load_current_resource
   @current_resource.name(@new_resource.name)
   @current_resource.property(@new_resource.property)
   @current_resource.value(@new_resource.value)
+  @current_resource.enable_escape(@new_resource.enable_escape)
   @current_resource.restart(@new_resource.restart)
 end
 
@@ -79,10 +80,15 @@ def property_exists?
 end
 
 def property_set
+  val = if current_resource.enable_escape
+          Shellwords.escape(current_resource.value)
+        else
+          value
+        end
   if property_exists?
-    result = shell_out("bin/jboss-cli.sh -c '/system-property=#{current_resource.property}:write-attribute(name=value,value=\"#{Shellwords.escape(current_resource.value)}\")'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
+    result = shell_out("bin/jboss-cli.sh -c '/system-property=#{current_resource.property}:write-attribute(name=value,value=\"#{val}\")'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
   else
-    result = shell_out("bin/jboss-cli.sh -c '/system-property=#{current_resource.property}:add(value=\"#{Shellwords.escape(current_resource.value)}\")'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
+    result = shell_out("bin/jboss-cli.sh -c '/system-property=#{current_resource.property}:add(value=\"#{val}\")'", user: node['wildfly']['user'], cwd: node['wildfly']['base'])
   end
   result.exitstatus.zero?
 end

--- a/providers/property.rb
+++ b/providers/property.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# rubocop:disable LineLength, Metrics/AbcSize, Style/MethodLength
+# rubocop:disable LineLength, Metrics/AbcSize, Metrics/MethodLength
 
 # encoding: UTF-8
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
-#
+
 # Cookbook Name:: wildfly
 # Recipe:: default
 #

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# rubocop:disable LineLength
+# rubocop:disable LineLength,SymbolArray
 
 # encoding: UTF-8
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -1,6 +1,8 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 # rubocop:disable LineLength
-#
+
+# encoding: UTF-8
+
 # Cookbook Name:: wildfly
 # Recipe:: install
 #

--- a/recipes/mysql_connector.rb
+++ b/recipes/mysql_connector.rb
@@ -1,6 +1,8 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 # rubocop:disable LineLength
-#
+
+# encoding: UTF-8
+
 # Cookbook Name:: wildfly
 # Recipe:: mysql_connector
 #

--- a/recipes/mysql_datasources.rb
+++ b/recipes/mysql_datasources.rb
@@ -1,6 +1,8 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 # rubocop:disable LineLength
-#
+
+# encoding: UTF-8
+
 # Cookbook Name:: wildfly
 # Recipe:: mysql_datasources
 #

--- a/recipes/postgres_connector.rb
+++ b/recipes/postgres_connector.rb
@@ -1,6 +1,8 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 # rubocop:disable LineLength
-#
+
+# encoding: UTF-8
+
 # Cookbook Name:: wildfly
 # Recipe:: postgres_connector
 #

--- a/recipes/postgres_datasources.rb
+++ b/recipes/postgres_datasources.rb
@@ -1,6 +1,8 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 # rubocop:disable LineLength
-#
+
+# encoding: UTF-8
+
 # Cookbook Name:: wildfly
 # Recipe:: postgres_datasources
 #

--- a/resources/attribute.rb
+++ b/resources/attribute.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
-#
+
 # LWRP that sets an attribute
 #
 # Copyright (C) 2014 Brian Dwyer - Intelligent Digital Services

--- a/resources/datasource.rb
+++ b/resources/datasource.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
-#
+
 # LWRP that provisions a datasource
 #
 # Copyright (C) 2014 Brian Dwyer - Intelligent Digital Services

--- a/resources/deploy.rb
+++ b/resources/deploy.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
-#
+
 # LWRP that deploys war "name" from either path :path or url :url
 #
 # Copyright (C) 2014 Brian Dwyer - Intelligent Digital Services

--- a/resources/logcategory.rb
+++ b/resources/logcategory.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
-#
+
 # LWRP that provisions a datasource
 #
 # Copyright (C) 2014 Brian Dwyer - Intelligent Digital Services

--- a/resources/loghandler.rb
+++ b/resources/loghandler.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
-#
+
 # LWRP that provisions a datasource
 #
 # Copyright (C) 2014 Brian Dwyer - Intelligent Digital Services

--- a/resources/property.rb
+++ b/resources/property.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
-#
+
 # LWRP that sets a system property
 #
 # Copyright (C) 2014 Brian Dwyer - Intelligent Digital Services

--- a/resources/property.rb
+++ b/resources/property.rb
@@ -24,5 +24,6 @@ attribute :name,          kind_of: String, required: true, name_attribute: true
 attribute :property,      kind_of: String, required: true
 attribute :value,         kind_of: String
 attribute :restart,       kind_of: [TrueClass, FalseClass], default: true
+attribute :enable_escape, kind_of: [TrueClass, FalseClass], default: true
 
 attr_accessor :exists


### PR DESCRIPTION
# Problem

I attempted to save a MongoDB URI as a system property using the `wildfly_property` resource, but the call to `Shellwords.escape` mangled my string and prevented the `jboss-cli.sh` from setting that system property.

My MongoDB URI connection string looked like this:

```
mongodb://user:password@ip-10-110-1-1.test.com,ip-10-110-1-2.test.com,ip-10-110-3.test.com/admin?ssl=true&replicaSet=set0
```

# Solution 

I've added an option to disallow escaping. By default, the option is enabled thus allowing for backwards compatibility.