### PR TITLE
Bump Version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ maintainer_email 'bdwyertech'
 license          'Apache-2.0'
 description      'Installs/Configures wildfly'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.2'
+version          '0.4.3'
 chef_version     '>= 12.4'
 
 supports 'centos'


### PR DESCRIPTION
When https://github.com/bdwyertech/chef-wildfly/pull/54 was merged, if fixed the bad chef version issue, but the version wasn't bumped so supermarket it still forcing the `<= 12.4` dependency.  Bumping the version should fix it.

Thanks!