### PR TITLE
1.1.0

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -6,8 +6,10 @@ driver:
   chef_version: <%= ENV['CHEF_VERSION'] || 'stable' %>
   ports: [
     '8080',
-    '9990'
-  ]
+    '9990',
+    '8082',
+    '9992',
+    ]
 
 transport:
   name: dokken
@@ -88,7 +90,7 @@ suites:
       'centos-7',
       'ubuntu-14.04',
       'ubuntu-16.04',
-    ]
+      ]
 
   - name: 'resource'
     run_list:
@@ -106,7 +108,7 @@ suites:
       'centos-7',
       'ubuntu-14.04',
       'ubuntu-16.04'
-    ]
+      ]
 
   - name: 'api'
     run_list:
@@ -125,4 +127,4 @@ suites:
       'centos-7',
       'ubuntu-14.04',
       'ubuntu-16.04'
-    ]
+      ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,16 +24,16 @@ env:
   - INSTANCE=default-ubuntu-1404
   - INSTANCE=default-ubuntu-1604
   - INSTANCE=default-amazon
-  - INSTANCE=default-centos-7 CHEF_VERSION=12.11.18
-  - INSTANCE=default-ubuntu-1404 CHEF_VERSION=12.11.18
+  - INSTANCE=default-centos-7 CHEF_VERSION=12.19.36
+  - INSTANCE=default-ubuntu-1404 CHEF_VERSION=12.19.36
   - INSTANCE=resource-centos-7
   - INSTANCE=resource-ubuntu-1404
   - INSTANCE=resource-ubuntu-1604
   - INSTANCE=resource-amazon
-  - INSTANCE=resource-ubuntu-1604 CHEF_VERSION=12.11.18
-  - INSTANCE=resource-amazon CHEF_VERSION=12.11.18
+  - INSTANCE=resource-ubuntu-1604 CHEF_VERSION=12.19.36
+  - INSTANCE=resource-amazon CHEF_VERSION=12.19.36
   - INSTANCE=api-centos-7
-  - INSTANCE=api-centos-7 CHEF_VERSION=12.11.18
+  - INSTANCE=api-centos-7 CHEF_VERSION=12.19.36
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 WildFly Cookbook CHANGELOG
 ==========================
 
+# 1.1.0 (2018-5-28)
+* WildFly 12.0.0
+* Update Java to 8u171
+* Add support for Ubuntu on the Supermarket
+* Bump minimum supported Chef version due to Chef 12 and [compat_resource deprecation](https://github.com/chef-boneyard/compat_resource)
+* Adjust tests for CLI deploy resource seemingly ignoring --name when --url is specified in 12.0.0 (Works fine via API)
+
 # 1.0.1 (2018-2-6)
 * Update README
 * Add support for Ubuntu on the Supermarket

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,9 +16,9 @@
 
 # => Wildfly Configuration
 # => Source
-default['wildfly']['version'] = '11.0.0'
-default['wildfly']['url'] = 'http://download.jboss.org/wildfly/11.0.0.Final/wildfly-11.0.0.Final.tar.gz'
-default['wildfly']['checksum'] = 'a2f5fb4187369196003e31eb086f0a1f7bfc0645a3a61a53ed20ab5853481e71'
+default['wildfly']['version'] = '12.0.0'
+default['wildfly']['url'] = 'http://download.jboss.org/wildfly/12.0.0.Final/wildfly-12.0.0.Final.tar.gz'
+default['wildfly']['checksum'] = '42fa41b25a2cbf4782f78fd8c4d537a06acfa60688fcc0ece9299f140c76afe0'
 
 # => Base Directory
 default['wildfly']['base'] = '/opt/wildfly'

--- a/attributes/java.rb
+++ b/attributes/java.rb
@@ -19,5 +19,5 @@
 default['java']['install_flavor'] = 'oracle'
 default['java']['oracle']['accept_oracle_download_terms'] = true
 default['java']['jdk_version'] = '8'
-default['java']['jdk']['8']['x86_64']['url'] = 'http://download.oracle.com/otn-pub/java/jdk/8u162-b12/0da788060d494f5095bf8624735fa2f1/jdk-8u162-linux-x64.tar.gz'
-default['java']['jdk']['8']['x86_64']['checksum'] = '68ec82d47fd9c2b8eb84225b6db398a72008285fafc98631b1ff8d2229680257'
+default['java']['jdk']['8']['x86_64']['url'] = 'http://download.oracle.com/otn-pub/java/jdk/8u171-b11/512cd62ec5174c3487ac17c61aaa89e8/jdk-8u171-linux-x64.tar.gz'
+default['java']['jdk']['8']['x86_64']['checksum'] = 'b6dd2837efaaec4109b36cfbb94a774db100029f98b0d78be68c27bec0275982'

--- a/chefignore
+++ b/chefignore
@@ -59,8 +59,10 @@ Procfile
 spec/*
 Rakefile
 .travis.yml
+.gitlab-ci.yml
 .foodcritic
 .codeclimate.yml
+scratchpad.rb
 
 # SCM #
 #######

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ license          'Apache-2.0'
 description      'Installs/Configures wildfly'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.0.1'
-chef_version     '>= 12.11'
+chef_version     '>= 12.19' if respond_to?(:chef_version)
 
 supports 'centos'
 supports 'ubuntu'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'bdwyertech'
 license          'Apache-2.0'
 description      'Installs/Configures wildfly'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.1'
+version          '1.1.0'
 chef_version     '>= 12.19' if respond_to?(:chef_version)
 
 supports 'centos'

--- a/resources/deploy.rb
+++ b/resources/deploy.rb
@@ -121,7 +121,7 @@ action_class do
   def deploy_install(source, deploy_name, runtime_name)
     Chef::Log.info("Deploying #{deploy_name}")
     converge_by((source == '' ? 'Enabling' : 'Deploying') + " #{detailed_name(runtime_name, deploy_name)}") do
-      result = jb_cli("deploy #{source} --name=#{deploy_name} --runtime-name=#{runtime_name}", new_resource.instance)
+      result = jb_cli("deploy #{source} --name=#{deploy_name} --runtime-name=#{runtime_name} --force", new_resource.instance)
       result.error! if result.exitstatus != 0
     end
     true

--- a/resources/logcategory.rb
+++ b/resources/logcategory.rb
@@ -22,7 +22,7 @@
 # => Define the Resource Name
 resource_name :wildfly_logcategory
 
-property :logger, String, name_property: true
+property :category, String, name_property: true
 property :use_parent_handlers, String
 property :level,    String
 property :handlers, Array
@@ -64,7 +64,7 @@ action_class do
   include WildFly::Helper
 
   def logcategory_exists?
-    result = jb_cli("/subsystem=logging/logger=#{new_resource.logger}:read-resource", new_resource.instance)
+    result = jb_cli("/subsystem=logging/logger=#{new_resource.category}:read-resource", new_resource.instance)
     result.exitstatus == 0
   end
 
@@ -84,10 +84,10 @@ action_class do
       "handlers=#{handlers}",
     ].join(',')
 
-    jb_cli("/subsystem=logging/logger=#{new_resource.logger}:add(#{params})", new_resource.instance)
+    jb_cli("/subsystem=logging/logger=#{new_resource.category}:add(#{params})", new_resource.instance)
   end
 
   def delete_logcategory
-    jb_cli("/subsystem=logging/logger=#{new_resource.logger}:remove", new_resource.instance)
+    jb_cli("/subsystem=logging/logger=#{new_resource.category}:remove", new_resource.instance)
   end
 end

--- a/test/fixtures/cookbooks/test/recipes/resource.rb
+++ b/test/fixtures/cookbooks/test/recipes/resource.rb
@@ -109,8 +109,19 @@ wildfly_deploy 'helloworld' do
   url 'https://github.com/efsavage/hello-world-war/raw/master/dist/hello-world.war'
 end
 
+# => BUG: The deploy resource in WildFly 12.0.0.FINAL doesn't seem to respect the name attribute when a url is specified...
+# => Here, we use a remote_file instead to get around it.  It works above because runtime_name is equal to the name (runtime_name still respected)
+
+# => File-Based Deployment
+cd = remote_file 'cluster-demo' do
+  source 'https://github.com/bdwyertech/cluster-demo/releases/download/011218/cluster-demo.war'
+  path ::File.join(Chef::Config[:file_cache_path], 'hello-world.war')
+  mode '0644'
+  action :create
+end
+
 wildfly_deploy 'cluster-demo-v1' do
   instance 'wildfly2'
-  url 'https://github.com/bdwyertech/cluster-demo/releases/download/011218/cluster-demo.war'
-  runtime_name 'cluster-demo'
+  path cd.path
+  runtime_name 'cluster-demo.war'
 end


### PR DESCRIPTION
# 1.1.0 (2018-5-29)
* WildFly 12.0.0
* Update Java to 8u171
* Add support for Ubuntu on the Supermarket
* Bump minimum supported Chef version due to Chef 12 and [compat_resource deprecation](https://github.com/chef-boneyard/compat_resource)
* Adjust tests for CLI deploy resource seemingly ignoring --name when --url is specified in 12.0.0 (Works fine via API)